### PR TITLE
Swap docker for containerd

### DIFF
--- a/.github/workflows/create-deployment.yml
+++ b/.github/workflows/create-deployment.yml
@@ -1,0 +1,32 @@
+name: Create Date-Based Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for creating releases
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set version with current date-time
+        id: set_version
+        run: echo "VERSION=$(date -u +'%Y%m%d-%H%M%S')" >> $GITHUB_ENV
+
+      - name: Zip amazon-eks-diag directory
+        run: |
+          cd amazon-eks-diag
+          zip -r ../amazon-eks-diag.zip ./*
+          cd ..
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          files: amazon-eks-diag.zip

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Following is a categorical overview of the diagnostic information gathered by th
     * Get-EventLog -LogName 'EKS'
     * Get-Service -Name 'kubelet'
     * Get-Service -Name 'kube-proxy'
-    * Get-Service -Name 'docker'
+    * Get-Service -Name 'containerd'
     * Get-Service -Name 'AmazonSSMAgent'
 3. Related executable output
-    * docker ps -a
-    * docker images -a
-    * docker network ls
+    * ctr.exe -n "k8s.io" containers list
+    * ctr.exe -n "k8s.io" images list
+    * ctr.exe -n "k8s.io" events
     * aws-iam-authenticator version
     * kubelet --version
     * kube-proxy --version

--- a/amazon-eks-diag/functions/Public/Start-EKSDiag.ps1
+++ b/amazon-eks-diag/functions/Public/Start-EKSDiag.ps1
@@ -180,7 +180,7 @@ Function Start-EKSDiag {
                     Verbose = [switch]::Present
                 },
                 @{
-                    Name    = 'docker'
+                    Name    = 'containerd'
                     Verbose = [switch]::Present
                 },
                 @{
@@ -207,10 +207,10 @@ Function Start-EKSDiag {
         ########################################################################
 
         [hashtable]$exeComponents = @{
-            'docker.exe'                = @(
-                'ps -a',
-                'images -a',
-                'network ls'
+            'ctr.exe'                = @(
+                '-n "k8s.io" containers list',
+                '-n "k8s.io" images list',
+                '-n "k8s.io" events'
             )
             'aws-iam-authenticator.exe' = @('version')
             'kubelet'                   = @('--version')


### PR DESCRIPTION
Replace logging out docker with containerd as dockershim was removed.
https://docs.aws.amazon.com/eks/latest/userguide/dockershim-deprecation.html